### PR TITLE
chore: release 0.2.5  zoom architecture & adaptive anti-clipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Starfleet Engineering Report Generator - Changelog
 
+## Version 0.2.5 - September 17, 2025
+
+### Zoom & Anti-Clipping Architecture
+- Implemented text-only zoom: report body scales; charts and control bar remain visually steady using inverse scale wrappers (`.chart-no-zoom`, `.controls-no-zoom`).
+- Added chart base size selector (80%, 90%, 100%) with persistence (`wcr_chart_base_scale`).
+- Introduced dynamic right-edge safe zone (`safeZonePx`) with zoom-proportional expansion and conditional bump for large charts at high zoom.
+- Added internal `rightSafe` tiered margins (+10 at ≥1.3×, +2 at ≥1.35× plus transitional +4 when crossing threshold) to prevent late glyph clipping.
+- Adaptive post-render measurement for figure title/caption adds incremental `adaptivePad` (+4 then +8 only if needed) to eliminate residual single-character truncation at 1.3–1.4×.
+- SVG roots now `overflow: visible` to avoid stroke cropping.
+
+### Mobile & UX Enhancements
+- New `Collapsible` component groups controls on mobile with persisted open state.
+- Added `MobileActionBar` with Produce / Reroll / Share / Help / Stardate / Crew / More actions and haptic feedback.
+- Drawer component scaffold for future slide-in panels.
+- Improved sound controls (responsive layout, accessible labels, smaller text on mobile).
+- Header and section copy buttons now include icons and hide text labels on narrow viewports for space efficiency.
+
+### Utilities & Infrastructure
+- Haptics utility (`haptics.ts`) with light/medium/heavy/success/error vibration patterns respecting `prefers-reduced-motion`.
+- Media query hook (`useMediaQuery`).
+- Lazy KaTeX loader with math presence detection (`lazyKatex.ts`).
+- LTTB downsampling utilities (`chartDownsample.ts`) for future high-density chart optimization.
+- Sample export scripts & generated sample artifacts (PDF, DOCX, TXT) for distribution demo.
+
+### Fixes
+- Resolved final high-zoom (≥1.35×) edge-case clipping of last 1–2 characters in figure titles/captions.
+- Prevented control bar button wrapping/clipping at elevated zoom levels.
+
+### Technical Notes
+The anti-clipping solution layers: (1) dynamic container safe zone, (2) tiered internal margins, (3) adaptive DOM measurement with minimal incremental padding, (4) inverse-scaling strategy to avoid reflow/measurement instability in SVG charts.
+
+---
+
 ## Version 0.2.4 - September 14, 2025
 
 ### UI / Docs

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Live Demo](https://img.shields.io/badge/Live%20Demo-rocketmobster.github.io%2Fwarpcorereports-blue?logo=github)](https://rocketmobster.github.io/warpcorereports/)
 
-![v0.2.4 Demo](docs/media/v0.2.4-demo.gif)
+![v0.2.5 Demo](docs/media/v0.2.5-demo.gif)
 
 A Star Trek-themed engineering report generator with LCARS UI styling, designed to create authentic-looking Starfleet engineering reports with dynamic content, interactive charts, and sharing capabilities.
 
@@ -13,9 +13,15 @@ A Star Trek-themed engineering report generator with LCARS UI styling, designed 
 - Add your name/rank and optionally check "Add Name to References" to include the signer in References.
 - Use the ℹ️ buttons in the UI for quick help on Templates, Figure Bias, Presets, Produce vs Reroll, and References.
 
-## Recently Fixed
+## Recently Added (0.2.5)
 
-- Signing Engineer reference: When "Add Name to References" is checked, the References section now always includes a signing engineer entry and consistent numbering. See CHANGELOG 0.2.3.
+- Text-only zoom: Report text scales smoothly (0.8×–1.4×) while charts and the zoom/control bar remain visually steady via inverse scaling wrappers.
+- Chart base size selector (80/90/100%) with persistence across sessions.
+- Multi-layer anti-clipping system: dynamic safe zone padding, tiered internal `rightSafe` margins, transitional margin boost, adaptive post-render measurement, and SVG `overflow: visible` to eliminate right-edge truncation at high zoom.
+- Mobile collapsible control groups & mobile action bar with haptic feedback.
+- Copy buttons now include icons and responsive labels.
+
+See CHANGELOG 0.2.5 for full technical notes.
 
 ## Features
 
@@ -29,6 +35,8 @@ A Star Trek-themed engineering report generator with LCARS UI styling, designed 
 - **Seed-Based Generation**: Use seeds for reproducible reports
 - **LCARS Sound Effects**: Authentic Star Trek computer sounds for UI interactions
 - **Chart Editing**: Modify charts and visualizations with interactive editing tools
+- **Text-Only Zoom Architecture**: Scales typography while keeping charts a fixed visual size for stability
+- **Adaptive Anti-Clipping**: Eliminates edge truncation at high zoom via layered safety margins and measurement
 - **Footer**: LCARS-styled footer shows developer info, current app version, and a link to the GitHub repo. Version updates automatically on build.
 
 ## Quick Start
@@ -46,6 +54,16 @@ npm run preview
 
 ## Usage Guide
 
+### Zoom & Chart Size (since 0.2.5)
+
+- Use the zoom controls at the top of the report body to scale text-only from 80%–140%.
+- Charts maintain their visual footprint using an inverse scale wrapper (`.chart-no-zoom`) so axis alignment and legibility remain stable.
+- Select a chart base size (80%, 90%, 100%) to generate charts at that intrinsic width; changing this triggers a re-measure pass.
+- A dynamic right-side safe zone expands with zoom and adds internal tiered margins so the last character of titles/captions never clips.
+- An adaptive post-render pass adds minimal extra padding only if actual or near-overflow is detected.
+
+Technical layers: external safe zone → internal tiered `rightSafe` → transitional boost → adaptive measurement (incremental +4 / +8) → SVG overflow visibility.
+
 ### Basic Controls
 
 1. **Vessel Selection**: Choose from classic Star Trek vessels
@@ -57,10 +75,10 @@ npm run preview
 
 ### Produce vs Reroll
 
-- **Produce Report**: Applies the controls above (problems, detail, graphs, vessel, signatory, humor, figure bias, signatory reference, and seed) to create a new report. If you enter or lock a seed, it will be used; otherwise a seed is generated for you.
+- **Produce Report**: Applies the controls above (problems, detail, graphs, vessel, signature, humor, figure bias, signature reference, and seed) to create a new report. If you enter or lock a seed, it will be used; otherwise a seed is generated for you.
 - **Reroll Current Report**: Generates a new variation of the currently displayed report by creating a fresh seed (and stardate) while preserving the report’s existing settings (including Mission Template). Changes you make to the controls are NOT applied until you click Produce Report again.
 - **What changes on Reroll**: Randomized content only — problem topics and summaries, chart data, references selection, and other generated flavor text.
-- **What stays on Reroll**: The settings used to produce the currently displayed report — counts, detail level, graphs toggle/count, Mission Template, figure bias, vessel, signatory info, humor level, and signatory-reference choice.
+- **What stays on Reroll**: The settings used to produce the currently displayed report — counts, detail level, graphs toggle/count, Mission Template, figure bias, vessel, signature info, humor level, and signature-reference choice.
 - **Seed lock nuance**: Seed lock affects the Seed control for Produce Report. Reroll always uses a fresh seed regardless of the lock or what’s currently typed in the Seed field.
 
 ### Advanced Features
@@ -161,7 +179,7 @@ The repository ignores accidental large artifacts and documents (e.g., screensho
 For quick exploration and fine-tuned randomness:
 
 - "🎲" buttons appear beside many controls and will randomize just that field:
-	- Problems, Problem Detail Level, Graphs On/Off, Graph Count, Starship, Signing Engineer, Rank, Seed, and Humor Level
+	- Problems, Problem Detail Level, Graphs On/Off, Graph Count, Starship, Signature (Engineer Name), Rank, Seed, and Humor Level
 - "Randomize All" randomizes all controls at once (respects the seed lock if enabled)
 - Tooltips on each "ðŸŽ²" button explain exactly what will be randomized
 

--- a/package.json
+++ b/package.json
@@ -1,16 +1,18 @@
 {
   "name": "starfleet-engineering-report",
   "private": true,
-  "version": "0.2.4",
+  "version": "0.2.5",
   "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-  "test:stardate": "node --experimental-specifier-resolution=node --loader ts-node/esm ./src/utils/stardate.test.ts",
-  "test:reportgen": "node --experimental-specifier-resolution=node --loader ts-node/esm ./src/utils/reportGen.test.ts",
-  "test": "npm run test:stardate && npm run test:reportgen",
-  "make:sample-pdf": "node --experimental-specifier-resolution=node --loader ts-node/esm ./scripts/make_sample_pdf.ts"
+    "test:stardate": "node --experimental-specifier-resolution=node --loader ts-node/esm ./src/utils/stardate.test.ts",
+    "test:reportgen": "node --experimental-specifier-resolution=node --loader ts-node/esm ./src/utils/reportGen.test.ts",
+    "test": "npm run test:stardate && npm run test:reportgen",
+    "make:sample-pdf": "node --experimental-specifier-resolution=node --loader ts-node/esm ./scripts/make_sample_pdf.ts",
+    "make:sample-docx": "node --experimental-specifier-resolution=node --loader ts-node/esm ./scripts/make_sample_docx.ts",
+    "make:sample-txt": "node --experimental-specifier-resolution=node --loader ts-node/esm ./scripts/make_sample_txt.ts"
   },
   "dependencies": {
     "chart.js": "^4.4.1",


### PR DESCRIPTION
## Summary
Release 0.2.5 introducing text-only zoom architecture, adaptive anti-clipping, mobile control ergonomics, and supporting utilities.

## Key Changes
### Zoom & Anti-Clipping
- Text-only zoom (0.8×–1.4×) with inverse scaling wrappers for charts & control bar.
- Chart base size selector (80/90/100%) with persistence (`wcr_chart_base_scale`).
- Layered right-edge protection: dynamic `safeZonePx`, tiered `rightSafe` (+10 / +2 + transitional +4), adaptive DOM measurement (`adaptivePad`), SVG `overflow: visible`.
- Eliminated final high-zoom clipping of figure titles/captions.

### Mobile & UX
- `Collapsible` control groups with persisted open state.
- `MobileActionBar` (Produce / Reroll / Share / Help / Stardate / Crew / More) with haptics.
- Drawer scaffold, improved sound controls, icon-enhanced copy buttons.

### Utilities & Infrastructure
- Haptics utilities (light/medium/heavy/success/error; respects reduced motion).
- Media query hook, lazy KaTeX loader with math detection.
- LTTB downsampling utilities for future large datasets.
- Sample export scripts & sample artifacts (PDF/DOCX/TXT).

### Fixes
- Prevented control bar wrapping at high zoom.
- Removed residual single-character truncation at ≥1.35× zoom.

### Docs
- Updated `README.md` with Zoom & Chart Size section and feature bullets.
- Added comprehensive 0.2.5 entry to `CHANGELOG.md`.

## Technical Notes
Anti-clipping approach layers: external safe zone padding → tiered internal margins → transitional margin boost → adaptive measurement (incremental +4 / +8) → SVG overflow visibility; paired with inverse chart scaling for stability.

## Version
`package.json` bumped to 0.2.5; annotated tag `v0.2.5` pushed.

## Checklist
- [x] Version bump
- [x] Changelog updated
- [x] README updated
- [x] Tag pushed (`v0.2.5`)
- [x] Branch up to date with `master` (please confirm no new commits landed on `master` before merging)

## Follow Ups
- Optional GitHub Release creation using the tag.
- Potential next step: PR to merge mobile refinements into future 0.3.0 roadmap.

🖖